### PR TITLE
SBIGNIT-137 - Reassign Class Applications when deleting the Type

### DIFF
--- a/src/DataAccess/Repositories/ClassApplicationsRepository.cs
+++ b/src/DataAccess/Repositories/ClassApplicationsRepository.cs
@@ -90,5 +90,16 @@ namespace DataAccess.Repositories
             splitOn: "DogName,Title");
             return result.ToList();
         }
+
+        public async Task<int> ReassignWholeClassType(IDbConnection conn, IDbTransaction tr, int currentClassTypeId, int targetClassTypeId)
+        {
+            var query = @$"
+                UPDATE {_tableName}
+                SET ClassTypeID = @targetClassTypeId, {GenerateTrackingSection()}
+                WHERE ClassTypeID = @currentClassTypeId
+            ";
+
+            return await conn.ExecuteAsync(query, new { targetClassTypeId, currentClassTypeId }, tr);
+        }
     }
 }

--- a/src/DataAccess/Repositories/Contracts/IClassApplicationsRepository.cs
+++ b/src/DataAccess/Repositories/Contracts/IClassApplicationsRepository.cs
@@ -1,9 +1,6 @@
 ﻿using DataAccess.Entities;
-using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DataAccess.Repositories.Contracts
@@ -11,5 +8,6 @@ namespace DataAccess.Repositories.Contracts
     public interface IClassApplicationsRepository : IRepository<ClassApplication>
     {
         Task<IReadOnlyList<ClassApplication>> GetAll(IDbConnection conn, string PaymentMethod, bool includePending, bool includeActive, bool includeCompleted, bool includeCancelled);
+        Task<int> ReassignWholeClassType(IDbConnection conn, IDbTransaction tr, int currentClassTypeId, int targetClassTypeId);
     }
 }

--- a/src/K9OCRS/ClientApp/src/areas/applications/Catalog/Classes.js
+++ b/src/K9OCRS/ClientApp/src/areas/applications/Catalog/Classes.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import * as classTypesClient from '../../../util/apiClients/classTypes';
-import { Container, Spinner, Row, Col } from 'reactstrap';
+import { Container, Spinner, Row, Col, Button } from 'reactstrap';
+import { isAdmin as verifyIsAdmin } from '../../../util/accessEvaluator';
 import Table from '../../../shared/components/Table';
 import sectionColumns from './components/sectionColumns';
 import PageHeader from '../../../shared/components/PageHeader';
@@ -9,6 +11,8 @@ import './components/style.scss';
 import PageBody from '../../../shared/components/PageBody';
 
 const Classes = (props) => {
+    const { isAdmin } = props;
+
     const { classTypeId } = useParams();
     const [classDetail, setClassDetail] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -47,7 +51,18 @@ const Classes = (props) => {
                     { label: classDetail.title ?? 'Class Details', active: true },
                 ]}
                 setAlerts={setAlerts}
-            />
+            >
+                { !isAdmin ? null : (
+                    <Button
+                        tag="a"
+                        href={`/Manage/Classes/Types/${classTypeId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Edit Class Type
+                    </Button>
+                )}
+            </PageHeader>
             <PageBody>
                 {loading ? <Spinner /> : null}
                 {!loading && (
@@ -115,4 +130,6 @@ const Classes = (props) => {
     );
 };
 
-export default Classes;
+export default connect((state) => ({
+    isAdmin: verifyIsAdmin(state?.shared?.currentUser),
+}), {})(Classes);

--- a/src/K9OCRS/Controllers/ClassTypesController.cs
+++ b/src/K9OCRS/Controllers/ClassTypesController.cs
@@ -295,7 +295,8 @@ namespace K9OCRS.Controllers
 
                     if (reassignSectionsToId != null)
                     {
-                        await dbOwner.ClassSections.ReassignWholeClassType(conn, tr, id, (int) reassignSectionsToId);
+                        await dbOwner.ClassSections.ReassignWholeClassType(conn, tr, id, (int)reassignSectionsToId);
+                        await dbOwner.ClassApplications.ReassignWholeClassType(conn, tr, id, (int)reassignSectionsToId);
                     }
 
                     var affectedRows = await dbOwner.ClassTypes.Delete(conn, tr, id);


### PR DESCRIPTION
Before, trying to "reassign and delete" a class type that had sections with applications on them would fail. That was caused by the FK constraint on the `ClassApplications` table. Making sure that the applications get reassigned as well as the sections fixes the issue